### PR TITLE
Define types within the subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
TypeScript ignores the top level `types` property when the `exports` object is defined. Instead, it will look for the `types` within the subpath exports (if defined).

Unfortunately, I am not able to find anything in the TypeScript official docs on this. However, their [4.7 release notes does talk about it](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing)

Screenshot of the relevant part 

<img width="915" alt="CleanShot 2022-09-26 at 14 04 33@2x" src="https://user-images.githubusercontent.com/1706381/192231521-253b9473-5b74-44cf-9acb-ea63a1c3c023.png">
